### PR TITLE
add RobustPmap explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ ForwardDiff
 BlackBoxOptim
 Distributions
 Mads
+RobustPmap


### PR DESCRIPTION
instead of assuming it will be present as an indirect dependency
